### PR TITLE
shade com.google.auto.common as proposed in https://github.com/google…

### DIFF
--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -59,4 +59,28 @@
             <artifactId>freemarker</artifactId>
         </dependency>
     </dependencies>
+
+   <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.auto.common</pattern>
+                                    <shadedPattern>org.jboss.gwt.circuit.processor.shaded.auto.common</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Shade com.google.auto.common to be able to avoid conflicts with other libraries.
E.g. auto-factory is using auto-common 0.4 which conflicts with 0.3 used in this project.