### PR TITLE
When using eclipse without maven-processor-plugin, void is not assign…

### DIFF
--- a/processor/src/main/java/org/jboss/gwt/circuit/processor/GenerationUtil.java
+++ b/processor/src/main/java/org/jboss/gwt/circuit/processor/GenerationUtil.java
@@ -30,6 +30,8 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.NoType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
@@ -68,7 +70,10 @@ final class GenerationUtil {
                     continue;
                 }
                 if (!typeUtils.isAssignable(actualReturnType, requiredReturnType)) {
-                    continue;
+                    NoType voidType = typeUtils.getNoType(TypeKind.VOID);
+                    if (!(voidType.equals(actualReturnType) && voidType.equals(requiredReturnType))) {
+                        continue;
+                    }
                 }
                 if (!doParametersMatch(typeUtils, elementUtils, e, requiredParameterTypes)) {
                     continue;


### PR DESCRIPTION
When using eclipse without maven-processor-plugin, one always gets the error "... does not contain suitable methods...".
Using maven-processor-plugin in eclipse makes errors only appear in the error log, not in the markers view where all compilation errors go into.
Thus, the errors are not marked in the code and one does not notice the error at all most of the time.
This makes the maven-processor-plugin unusable for us.

For this reason it'd be great if you could incorporate the fix although you obviously have no need for it.

If you prefer a wrapper for the Types class to encapsulate the compatibility logic I'd change that and create another pull request.
